### PR TITLE
Instance type generation information in product info

### DIFF
--- a/api/openapi-spec/productinfo.json
+++ b/api/openapi-spec/productinfo.json
@@ -301,6 +301,11 @@
           "format": "double",
           "x-go-name": "Cpus"
         },
+        "currentGen": {
+          "description": "CurrentGen signals whether the instance type generation is the current one. Only applies for amazon",
+          "type": "boolean",
+          "x-go-name": "CurrentGen"
+        },
         "gpusPerVm": {
           "type": "number",
           "format": "double",

--- a/api/openapi-spec/productinfo.yaml
+++ b/api/openapi-spec/productinfo.yaml
@@ -224,6 +224,12 @@ components:
           type: number
           format: double
           x-go-name: Cpus
+        currentGen:
+          description: >-
+            CurrentGen signals whether the instance type generation is the
+            current one. Only applies for amazon
+          type: boolean
+          x-go-name: CurrentGen
         gpusPerVm:
           type: number
           format: double

--- a/pkg/productinfo-client/models/product_details.go
+++ b/pkg/productinfo-client/models/product_details.go
@@ -24,6 +24,9 @@ type ProductDetails struct {
 	// cpus
 	Cpus float64 `json:"cpusPerVm,omitempty"`
 
+	// CurrentGen signals whether the instance type generation is the current one. Only applies for amazon
+	CurrentGen bool `json:"currentGen,omitempty"`
+
 	// gpus
 	Gpus float64 `json:"gpusPerVm,omitempty"`
 

--- a/pkg/productinfo/ec2/productinfo_ec2.go
+++ b/pkg/productinfo/ec2/productinfo_ec2.go
@@ -168,6 +168,13 @@ func (e *Ec2Infoer) GetProducts(regionId string) ([]productinfo.VmInfo, error) {
 			continue
 		}
 
+		var currGen bool
+		if currentGenStr, err := pd.GetDataForKey("currentGeneration"); err == nil {
+			if strings.ToLower(currentGenStr) == "yes" {
+				currGen = true
+			}
+		}
+
 		onDemandPrice, _ := strconv.ParseFloat(odPriceStr, 64)
 		cpus, _ := strconv.ParseFloat(cpusStr, 64)
 		mem, _ := strconv.ParseFloat(strings.Split(memStr, " ")[0], 64)
@@ -179,12 +186,14 @@ func (e *Ec2Infoer) GetProducts(regionId string) ([]productinfo.VmInfo, error) {
 			Mem:           mem,
 			Gpus:          gpus,
 			NtwPerf:       ntwPerf,
+			CurrentGen:    &currGen,
 		}
 		vms = append(vms, vm)
 	}
 	if vms == nil {
 		log.Debugf("couldn't find any virtual machines to recommend")
 	}
+
 	log.Debugf("found vms: %#v", vms)
 	return vms, nil
 }

--- a/pkg/productinfo/ec2/productinfo_ec2_test.go
+++ b/pkg/productinfo/ec2/productinfo_ec2_test.go
@@ -206,6 +206,10 @@ func TestNewEc2Infoer(t *testing.T) {
 	}
 }
 
+func boolPointer(c bool) *bool {
+	return &c
+}
+
 func TestEc2Infoer_GetAttributeValues(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -291,7 +295,7 @@ func TestEc2Infoer_GetProducts(t *testing.T) {
 			pricingService: &testStruct{TcId: 4},
 			check: func(vm []productinfo.VmInfo, err error) {
 				assert.Nil(t, err, "the error should be nil")
-				assert.Equal(t, []productinfo.VmInfo{{Type: "t2.small", OnDemandPrice: 5, SpotPrice: productinfo.SpotPriceInfo(nil), Cpus: 1, Mem: 2, Gpus: 0, NtwPerf: "Low to Moderate", NtwPerfCat: ""}}, vm)
+				assert.Equal(t, []productinfo.VmInfo{{Type: "t2.small", OnDemandPrice: 5, SpotPrice: productinfo.SpotPriceInfo(nil), Cpus: 1, Mem: 2, Gpus: 0, NtwPerf: "Low to Moderate", NtwPerfCat: "", CurrentGen: boolPointer(false)}}, vm)
 			},
 		},
 		{

--- a/pkg/productinfo/productinfo.go
+++ b/pkg/productinfo/productinfo.go
@@ -38,6 +38,8 @@ type VmInfo struct {
 	Gpus          float64       `json:"gpusPerVm"`
 	NtwPerf       string        `json:"ntwPerf"`
 	NtwPerfCat    string        `json:"ntwPerfCategory"`
+	// CurrentGen signals whether the instance type generation is the current one. Only applies for amazon
+	CurrentGen *bool `json:"currentGen"`
 }
 
 // IsBurst returns true if the EC2 instance vCPU is burst type


### PR DESCRIPTION
instance generation information added to product info - applies to ec2 only
- regenerated swagger
- regenerated pi client
- fxed tests
- tested locally