### PR TITLE
Oracle - Remove ondemand prices shown as spot ones

### DIFF
--- a/pkg/productinfo/oci/productinfo.go
+++ b/pkg/productinfo/oci/productinfo.go
@@ -109,13 +109,6 @@ func (i *Infoer) Initialize() (prices map[string]map[string]productinfo.Price, e
 
 			price := prices[region][product.Type]
 			price.OnDemandPrice = shapePrice
-
-			spotPrice := make(productinfo.SpotPriceInfo)
-			for _, zone := range zonesInRegions[region] {
-				spotPrice[zone] = shapePrice
-			}
-
-			price.SpotPrice = spotPrice
 			prices[region][product.Type] = price
 			log.Debugf("price info added: [region=%s, machinetype=%s, price=%v]", region, product.Type, price)
 		}

--- a/pkg/productinfo/types.go
+++ b/pkg/productinfo/types.go
@@ -160,7 +160,7 @@ type ProductDetails struct {
 	Burst bool `json:"burst,omitempty"`
 
 	// ZonePrice holds spot price information per zone
-	SpotInfo []ZonePrice `json:"spotPrice"`
+	SpotInfo []ZonePrice `json:"spotPrice,omitempty"`
 }
 
 // ProductDetailSource product details related set of operations


### PR DESCRIPTION
Oracle - Remove ondemand prices shown as spot ones. Oracle doesn't have spot instances.

Make spotPrice omitted in the JSON response if empty.