### PR TITLE
Validate path parameters - service

### DIFF
--- a/internal/app/productinfo/api/routes.go
+++ b/internal/app/productinfo/api/routes.go
@@ -65,9 +65,9 @@ func (r *RouteHandler) ConfigureRoutes(router *gin.Engine) {
 
 		providerGroup.GET("/", r.getProviders).Use(ValidatePathParam(providerParam, v, "provider"))
 		providerGroup.GET("/:provider", r.getProvider)
-		providerGroup.GET("/:provider/services", r.getServices)
+		providerGroup.GET("/:provider/services", r.getServices).Use(ValidatePathData(v))
 		providerGroup.GET("/:provider/services/:service", r.getService)
-		providerGroup.GET("/:provider/services/:service/regions", r.getRegions).Use(ValidateRegionData(v))
+		providerGroup.GET("/:provider/services/:service/regions", r.getRegions).Use(ValidatePathData(v))
 		providerGroup.GET("/:provider/services/:service/regions/:region", r.getRegion)
 		providerGroup.GET("/:provider/services/:service/regions/:region/images", r.getImages)
 		providerGroup.GET("/:provider/services/:service/regions/:region/products", r.getProducts)

--- a/internal/app/productinfo/api/types.go
+++ b/internal/app/productinfo/api/types.go
@@ -21,7 +21,7 @@ type GetProviderPathParams struct {
 type GetServicesPathParams struct {
 	GetProviderPathParams `mapstructure:",squash"`
 	// in:path
-	Service string `json:"service"`
+	Service string `binding:"service" json:"service"`
 }
 
 // GetRegionPathParams is a placeholder for the regions related route path parameters
@@ -29,7 +29,7 @@ type GetServicesPathParams struct {
 type GetRegionPathParams struct {
 	GetServicesPathParams `mapstructure:",squash"`
 	// in:path
-	Region string `json:"region"`
+	Region string `binding:"region" json:"region"`
 }
 
 // GetAttributeValuesPathParams is a placeholder for the get attribute values route's path parameters


### PR DESCRIPTION
- path parameter validation made more generic
- provider, service, region path parameters checked
- using api parameter structs for validation too (insted of internally defined structs)

fixes #58 