### PR TITLE
Parent context values taken into account when creating new contexts

### DIFF
--- a/cmd/productinfo/main.go
+++ b/cmd/productinfo/main.go
@@ -122,8 +122,8 @@ func init() {
 	// flags are available through the entire application via viper
 	bindFlags()
 
-	// a fallback/root logger for events without context
-	logger.Logger = logger.NewLogger()
+	// initialize the logging framework
+	logger.InitLogger(viper.GetString(logLevelFlag), viper.GetString(logFormatFlag))
 
 	// Viper check for an environment variable
 	viper.AutomaticEnv()

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,3 +1,17 @@
+// Copyright © 2018 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package logger
 
 import (

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
 
 type ctxMarker struct{}
 
 var (
 	ctxKey = &ctxMarker{}
+	logger = logrus.New() // default logger
 )
 
 const (
@@ -25,14 +25,14 @@ const (
 
 var ctxFields = []string{providerKey, regionKey, serviceKey, correlationIdKey, scrapeIdFullKey, scrapeIdShortKey}
 
-// NewLogger sets level and format for Logger
-func NewLogger() *logrus.Logger {
-	logger := newLogger(Config{
-		Level:  viper.GetString("log-level"),
-		Format: viper.GetString("log-format"),
+// InitLogger sets level and format for Logger
+func InitLogger(level, format string) {
+
+	logger = newLogger(Config{
+		Level:  level,
+		Format: format,
 	})
 
-	return logger
 }
 
 // Config holds information necessary for customizing the logger.
@@ -67,9 +67,10 @@ func newLogger(config Config) *logrus.Logger {
 
 // Extract assembles the entry with the fields extracted from the context
 func Extract(ctx context.Context) ContextLogger {
+
 	fds, ok := ctx.Value(ctxKey).(map[string]interface{})
 	if !ok || fds == nil {
-		return logrus.NewEntry(logrus.New())
+		return logrus.NewEntry(logger)
 	}
 
 	fields := logrus.Fields{}
@@ -77,7 +78,7 @@ func Extract(ctx context.Context) ContextLogger {
 		fields[k] = v
 	}
 
-	return logrus.New().WithFields(fields)
+	return logger.WithFields(fields)
 }
 
 // ToContext adds

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -1,0 +1,39 @@
+// Copyright © 2018 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logger
+
+import (
+	"context"
+	"testing"
+)
+
+func Test(t *testing.T) {
+
+	ctx := ToContext(context.Background(), NewLogCtxBuilder().
+		WithProvider("test-provider").
+		WithRegion("test-region").
+		Build())
+	Extract(ctx).Info("before routine")
+
+	done := make(chan bool)
+
+	go func(ctx context.Context, m chan bool) {
+		ctx1 := ToContext(ctx, NewLogCtxBuilder().WithField("inroutine", "haha").Build())
+		Extract(ctx1).Info("in routine")
+		m <- true
+	}(ctx, done)
+	<-done
+	Extract(ctx).Info("after routine")
+}

--- a/logger/middleware.go
+++ b/logger/middleware.go
@@ -1,3 +1,17 @@
+// Copyright © 2018 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package logger
 
 import (

--- a/pkg/productinfo/productinfo.go
+++ b/pkg/productinfo/productinfo.go
@@ -217,12 +217,9 @@ func (cpi *CachingProductInfo) renewProviderInfo(ctx context.Context, provider s
 	}
 
 	for regionId := range regions {
-
 		c := logger.ToContext(ctx,
 			logger.NewLogCtxBuilder().
-				WithProvider(provider).
 				WithRegion(regionId).
-				WithScrapeIdFull(atomic.LoadUint64(&scrapeCounterComplete)).
 				Build())
 
 		start := time.Now()
@@ -259,7 +256,7 @@ func (cpi *CachingProductInfo) renewAll(ctx context.Context) {
 		go cpi.renewProviderInfo(ctxWithFields, provider, &providerWg)
 	}
 	providerWg.Wait()
-	logger.Extract(ctx).WithField("scrapeIdComplete", atomic.LoadUint64(&scrapeCounterComplete)).Info("finished renewing product info")
+	logger.Extract(ctx).WithField("scarpe-id-full", atomic.LoadUint64(&scrapeCounterComplete)).Info("finished renewing product info")
 }
 
 func (cpi *CachingProductInfo) renewShortLived(ctx context.Context) {
@@ -291,9 +288,7 @@ func (cpi *CachingProductInfo) renewShortLived(ctx context.Context) {
 			var wg sync.WaitGroup
 			for regionId := range regions {
 				c = logger.ToContext(c, logger.NewLogCtxBuilder().
-					WithProvider(p).
 					WithRegion(regionId).
-					WithScrapeIdShort(atomic.LoadUint64(&scrapeCounterShortLived)).
 					Build())
 
 				wg.Add(1)
@@ -314,7 +309,7 @@ func (cpi *CachingProductInfo) renewShortLived(ctx context.Context) {
 		}(ctxWithFields, provider, infoer)
 	}
 	providerWg.Wait()
-	logger.Extract(ctx).WithField("scrapeIdShortLived", atomic.LoadUint64(&scrapeCounterShortLived)).Info("finished renewing short lived product info")
+	logger.Extract(ctx).WithField("scrape-id-short", atomic.LoadUint64(&scrapeCounterShortLived)).Info("finished renewing short lived product info")
 }
 
 // Start starts the information retrieval in a new goroutine


### PR DESCRIPTION
- Original values were overwritten in the toctx method
- the logger framework is always initialized
- basic test for the logger package (to be extended!!!)