### PR TITLE
fixed parent context field inheritance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ test:
 install-golint:
 	GOLINT_CMD=$(shell command -v golint 2> /dev/null)
 ifndef GOLINT_CMD
-	go get github.com/golang/lint/golint
+	go get -u golang.org/x/lint/golint
 endif
 
 install-misspell:

--- a/cmd/productinfo/main.go
+++ b/cmd/productinfo/main.go
@@ -181,11 +181,11 @@ func infoers(ctx context.Context) map[string]productinfo.ProductInfoer {
 	for _, p := range providers {
 		var infoer productinfo.ProductInfoer
 		var err error
-		ctx = logger.ToContext(ctx, logger.NewLogCtxBuilder().WithProvider(p).Build())
+		pctx := logger.ToContext(ctx, logger.NewLogCtxBuilder().WithProvider(p).Build())
 
 		switch p {
 		case Amazon:
-			infoer, err = amazon.NewEc2Infoer(ctx, viper.GetString(prometheusAddressFlag), viper.GetString(prometheusQueryFlag))
+			infoer, err = amazon.NewEc2Infoer(pctx, viper.GetString(prometheusAddressFlag), viper.GetString(prometheusQueryFlag))
 		case Google:
 			infoer, err = google.NewGceInfoer(viper.GetString(gceApiKeyFlag))
 		case Azure:
@@ -195,13 +195,13 @@ func infoers(ctx context.Context) map[string]productinfo.ProductInfoer {
 		case Alibaba:
 			infoer, err = alibaba.NewAlibabaInfoer(viper.GetString(alibabaRegionId), viper.GetString(alibabaAccessKeyId), viper.GetString(alibabaAccessKeySecret))
 		default:
-			logger.Extract(ctx).Fatal("provider is not supported")
+			logger.Extract(pctx).Fatal("provider is not supported")
 		}
 
-		quitOnError(ctx, "could not initialize product info provider", err)
+		quitOnError(pctx, "could not initialize product info provider", err)
 
 		infoers[p] = infoer
-		logger.Extract(ctx).Infof("Configured '%s' product info provider", p)
+		logger.Extract(pctx).Infof("Configured '%s' product info provider", p)
 	}
 	return infoers
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -81,13 +81,14 @@ func newLogger(config Config) *logrus.Logger {
 // Extract assembles the entry with the fields extracted from the context
 func Extract(ctx context.Context) ContextLogger {
 
-	fds, ok := ctx.Value(ctxKey).(map[string]interface{})
-	if !ok || fds == nil {
-		return logrus.NewEntry(logger)
+	var ctxFields map[string]interface{}
+
+	if fds, ok := ctx.Value(ctxKey).(map[string]interface{}); ok {
+		ctxFields = fds
 	}
 
 	fields := logrus.Fields{}
-	for k, v := range fds {
+	for k, v := range ctxFields {
 		fields[k] = v
 	}
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -98,11 +98,13 @@ func Extract(ctx context.Context) ContextLogger {
 // ToContext adds
 func ToContext(ctx context.Context, fields map[string]interface{}) context.Context {
 
-	var mergedFields map[string]interface{}
+	mergedFields := make(map[string]interface{})
 
 	// retrieving the "parent" context
 	if parentVals, ok := ctx.Value(ctxKey).(map[string]interface{}); ok {
-		mergedFields = parentVals
+		for k, v := range parentVals {
+			mergedFields[k] = v
+		}
 	}
 
 	if mergedFields == nil {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -113,7 +113,7 @@ func ToContext(ctx context.Context, fields map[string]interface{}) context.Conte
 	for k, v := range fields { // copy parent context values into the current context
 		mergedFields[k] = v
 	}
-	
+
 	return context.WithValue(ctx, ctxKey, mergedFields)
 }
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -97,21 +97,24 @@ func Extract(ctx context.Context) ContextLogger {
 // ToContext adds
 func ToContext(ctx context.Context, fields map[string]interface{}) context.Context {
 
-	// retrieving the "parent" context
-	parentVals, ok := ctx.Value(ctxKey).(map[string]interface{})
+	var mergedFields map[string]interface{}
 
-	if parentVals == nil && ok {
+	// retrieving the "parent" context
+	if parentVals, ok := ctx.Value(ctxKey).(map[string]interface{}); ok {
+		mergedFields = parentVals
+	}
+
+	if mergedFields == nil {
 		// there is no logger context set in the parent
 		return context.WithValue(ctx, ctxKey, fields)
 	}
 
-	if ok { // the parent context is successfully retrieved
-		for k, v := range parentVals { // copy parent context values into the current context
-			fields[k] = v
-		}
+	// the parent context is successfully retrieved
+	for k, v := range fields { // copy parent context values into the current context
+		mergedFields[k] = v
 	}
-
-	return context.WithValue(ctx, ctxKey, fields)
+	
+	return context.WithValue(ctx, ctxKey, mergedFields)
 }
 
 // GetCorrelationId get correlation id from gin context


### PR DESCRIPTION
- fixed the handling of fields in the contextlogger
(fields from the parent context weren't copied over - and overridden if  necessary)
- added unit tests